### PR TITLE
Finish with the warning on launch

### DIFF
--- a/lib/i2c/drivers/mcp23008.rb
+++ b/lib/i2c/drivers/mcp23008.rb
@@ -13,12 +13,12 @@
 require 'i2c/i2c.rb'
 
 # Constants for mode()
-INPUT = 1
-OUTPUT = 0
+INPUT = 1   unless defined?(INPUT)
+OUTPUT = 0  unless defined?(OUTPUT)
 
 # Constants for write()
-HIGH = 1
-LOW = 0
+HIGH = 1    unless defined?(HIGH)
+LOW = 0     unless defined?(LOW)
       
 module I2C
   module Drivers

--- a/lib/i2c/drivers/mcp23017.rb
+++ b/lib/i2c/drivers/mcp23017.rb
@@ -13,12 +13,12 @@
 require 'i2c/i2c.rb'
 
 # Constants for mode()
-INPUT = 1
-OUTPUT = 0
+INPUT = 1   unless defined?(INPUT)
+OUTPUT = 0  unless defined?(OUTPUT)
 
 # Constants for write()
-HIGH = 1
-LOW = 0
+HIGH = 1    unless defined?(HIGH)
+LOW = 0     unless defined?(LOW)
       
 module I2C
   module Drivers


### PR DESCRIPTION
Hello,

I hava a small problem. When i use your gem (thanks for it), i get theses warnings.

/home/sebastien/.rvm/gems/ruby-1.9.3-p392/gems/i2c-0.2.0/lib/i2c/drivers/mcp23017.rb:16: warning: already initialized constant INPUT
/home/sebastien/.rvm/gems/ruby-1.9.3-p392/gems/i2c-0.2.0/lib/i2c/drivers/mcp23017.rb:17: warning: already initialized constant OUTPUT
/home/sebastien/.rvm/gems/ruby-1.9.3-p392/gems/i2c-0.2.0/lib/i2c/drivers/mcp23017.rb:20: warning: already initialized constant HIGH
/home/sebastien/.rvm/gems/ruby-1.9.3-p392/gems/i2c-0.2.0/lib/i2c/drivers/mcp23017.rb:21: warning: already initialized constant LOW

This small commit disable these messages.

Good afternoon
