### PR TITLE
Multithreading smooth-out

### DIFF
--- a/i2c.gemspec
+++ b/i2c.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
   s.name        = 'i2c'
-  s.version     = '0.4.1'
-  s.date        = '2017-08-23'
+  s.version     = '0.4.2-dev'
+  s.date        = '2018-06-04'
   s.summary     = "I2C access library (for Linux)."
   s.description = "Interface to I2C (aka TWI) implementations. Also provides abstractions for some I2c-devices. Created with the Raspberry Pi in mind."
   s.authors     = ["Christoph Anderegg"]
   s.email       = 'christoph@christoph-anderegg.ch'
-  s.files       = ["lib/i2c.rb", 
-  		   "lib/i2c/i2c.rb", 
-		   "lib/i2c/backends/i2c-dev.rb", 
+  s.files       = ["lib/i2c.rb",
+  		   "lib/i2c/i2c.rb",
+		   "lib/i2c/backends/i2c-dev.rb",
   		   "lib/i2c/drivers/mcp230xx.rb",
 		   "test//mcp230xx_spec.rb",
 		   "rules/88-i2c.rules"]

--- a/lib/i2c/backends/i2c-dev.rb
+++ b/lib/i2c/backends/i2c-dev.rb
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-# I2C - Linux i2c-dev backend. 
+# I2C - Linux i2c-dev backend.
 #
 # Copyright (c) 2012 Christoph Anderegg <christoph@christoph-anderegg.ch>
-# Copyright (c) 2008 Jonas Bähr, jonas.baehr@fs.ei.tum.de 
+# Copyright (c) 2008 Jonas Bähr, jonas.baehr@fs.ei.tum.de
 # This file may be distributed under the terms of the GNU General Public
 # License Version 2.
 #
@@ -25,34 +25,25 @@ module I2C
     # For Fixnum there is a convinient function to_short which transforms
     # the number to a string this way: 12345.to_short == [12345].pack("s")
     def write(address, *params)
-      data = String.new
-      data.force_encoding("US-ASCII")
-      params.each do |value|
-        data << value
-      end
-      @device.ioctl(I2C_SLAVE, address)
-      @device.syswrite(data)
+		setup_device(address);
+		raw_write(params);
     end
 
-    # this sends *params as the write function and then tries to read
+    # this sends *params, if given, and then tries to read
     # +size+ bytes. The result is a String which can be treated with
     # String#unpack afterwards
     def read(address, size, *params)
-      ret = ""
-      write(address, *params) unless params == nil
-      ret = @device.sysread(size)
-      return ret
+		setup_device(address);
+		raw_write(params) unless params.empty?
+		return raw_read(size);
     end
-    
+
     # Read a byte from the current address. Return a one char String which
     # can be treated with String#unpack
     def read_byte(address)
-      ret=""
-      @device.ioctl(I2C_SLAVE,address)
-      ret=@device.sysread(1)
-      return ret
+   	read(address, 1);
     end
-    
+
     private
 	 def setup_device(address)
 		 @device.ioctl(I2C_SLAVE, address);

--- a/lib/i2c/backends/i2c-dev.rb
+++ b/lib/i2c/backends/i2c-dev.rb
@@ -45,14 +45,18 @@ module I2C
     end
 
     private
+	 # Set up @device for a I2C communication to address
 	 def setup_device(address)
 		 @device.ioctl(I2C_SLAVE, address);
 	 end
 
+	 # Read size bytes from @device, if possible. Raise an error otherwise
 	 def raw_read(size)
 		 return @device.sysread(size)
 	 end
 
+	 # Write "params" to @device, unrolling them first should they be an array.
+	 # params should be a string, formatted with Array.pack as explained for write() 
 	 def raw_write(params)
 		 data = String.new();
 		 data.force_encoding("US-ASCII")

--- a/lib/i2c/backends/i2c-dev.rb
+++ b/lib/i2c/backends/i2c-dev.rb
@@ -54,6 +54,27 @@ module I2C
     end
     
     private
+	 def setup_device(address)
+		 @device.ioctl(I2C_SLAVE, address);
+	 end
+
+	 def raw_read(size)
+		 return @device.sysread(size)
+	 end
+
+	 def raw_write(params)
+		 data = String.new();
+		 data.force_encoding("US-ASCII")
+
+		 if(params.is_a? Array)
+			 params.each do |i| data << i; end
+		 else
+			 data << params;
+		 end
+
+		 @device.syswrite(data);
+	 end
+
     def initialize(device_path)
       @device = File.new(device_path, 'r+')
       # change the sys* functions of the file object to meet our requirements


### PR DESCRIPTION
Hey there!
For my smart home project, as I expanded it, I began to notice a few odd behaviours of my I2C-connected components.

Upon analysis with my Salea, I noticed two things:
- There was an unnecessary write in front of read operations. SLA+W was sent, but no data. (No data was expected)
- Communications seemed to get mixed up with each other.

The former point was a simple manner of rewriting the `read()` code to not always execute the `write` function.
The second point was a lack of synchronisation between multiple threads, allowing different Threads to simultaneously write to `@device`, thusly confusing what data and address were sent where.

The mutex I added makes sure that only one Thread can ever access the `@device` between setting address, writing and reading. It can additionally be accessed and locked manually, to perform multiple consecutive read or write operations to single or multiple devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andec/i2c/7)
<!-- Reviewable:end -->
